### PR TITLE
Write up modified proposal.

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -297,46 +297,49 @@ record, and do not have to be trusted to mitigate impersonation.
 
 ## Modified proposal
 
-Roughly, we replace `S` and `L` by the `sk` and `vk` of a signature scheme.
+Roughly, we replace `S` and `L` by the signing and verification keys of a
+signature scheme.
 
-The app generates signing and verification keys `sk` (the *report authorization
-key*) and `vk` of a signature scheme, and computes the initial CEN key as
+The app creates `rak` (the *report authorization key*) and `rvk` (the *report
+verification key*) as the signing and verification keys of a signature scheme.
+Then it computes the initial *CEN key* as
 ```
-k_0 ← H_k(sk).
+k_0 ← H_k(rak).
 ```
 CEN keys are updated by computing
 ```
-k_i ← H_k(vk || k_{i-1}).
+k_i ← H_k(rvk || k_{i-1}).
 ```
 CENs are derived from the CEN key by computing
 ```
 CEN_i ← H_CEN(le_u16(i) || k_i).
 ```
-Note that each report authorization key can create at most `2**16` CENs.
+Note that each report authorization key can create at most `2**16` CENs.  In
+practice, reports should be rotated more frequently.
 
 A user wishing to notify contacts they encountered over the period `j1` to `j2`
 prepares a report as
 ```
-report ← vk || k_{j1} || le_u16(j1) || le_u16(j2) || memo
+report ← rvk || k_{j1} || le_u16(j1) || le_u16(j2) || memo
 ```
 where `memo` is a variable-length bytestring with the following structure:
 ```
 len: u8 || type: u8 || data: [u8; len]
 ```
-Then they use `sk` to produce `sig`, a signature over `report`, and send
+Then they use `rsk` to produce `sig`, a signature over `report`, and send
 `report || sig` to the server.
 
 Anyone can verify the source integity of the report by checking `sig` over
-`report` using the included `vk`, and recompute the CENs as
+`report` using the included `rvk`, and recompute the CENs as
 ```
 CEN_j1 ← H_CEN(le_u16(j1) || k_{j1})
-k_{j1+1} ← H_k(vk || k_{j1})
+k_{j1+1} ← H_k(rvk || k_{j1})
 CEN_{j1+1} ← H_CEN(le_u16(j1+1) || k_{j1+1})
 ...
 ```
 Using SHA256 and Ed25519, reports are `134-390` bytes each, depending on the
-length of the memo field.  Servers can optionally strip the trailing 64 bytes
-of each report if client verification is not important.
+length of the memo field.  The server can optionally strip the trailing 64 byte 
+`sig` from each report if client verification is not important.
 
 ## Attacks
 


### PR DESCRIPTION
I think this preserves the important properties of the Danezis proposal, while simplifying it slightly. 

 It also specifies a compact format for reports that allows extensible, freeform messages.  Each report includes a small amount of variable-length data in a memo field.  Depending on the length of the memo field, reports are **between 134 and 370 bytes**, or **70 and 326 bytes** if user verification of source integrity is not important (i.e., if the server is trusted to verify reports were generated correctly).

The memo field includes a type byte, which can be allocated to applications.  For instance, we could define a schema like 
- `0x0`: "CoEpi symptom bitflags v1",
- `0x1`: "CovidWatch test result" (maybe this is a 64-byte signature from a testing portal),
- `0xfe`: reserved (can be used to add more than 256 types later),
- `0xff`: binary data,