### PR TITLE
Add a test that generates test vectors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ ed25519-zebra = "0.2.2"
 [dev-dependencies]
 rand = "0.7"
 hex = "0.4"
+rand_chacha = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ ed25519-zebra = "0.2.2"
 
 [dev-dependencies]
 rand = "0.7"
+hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ encoded by the `type` field, which has the following meaning:
 These parameter choices result in signed reports of 134-389 bytes or unsigned
 reports of 70-325 bytes, depending on the length of the memo field.
 
+**Test vectors** can be generated via
+```
+cargo test generate_test_vectors -- --nocapture
+```
+
 ## TCN sharing with Bluetooth Low Energy
 
 Applications following this protocol use iOS and Android apps' capability to share a 128-bit Temporary Contact Number (TCN) with nearby apps using Bluetooth Low Energy (BLE).

--- a/tests/test_vectors.rs
+++ b/tests/test_vectors.rs
@@ -1,11 +1,15 @@
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use std::io::Cursor;
+
 use tcn::*;
 
 // Run cargo test generate_test_vectors -- --nocapture
 #[test]
 fn generate_test_vectors() {
-    use std::io::Cursor;
+    // This is insecure!! It's only done for reproducibility.
+    let rng = ChaChaRng::from_seed([0x19; 32]);
 
-    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+    let rak = ReportAuthorizationKey::new(rng);
 
     let mut buf = Vec::new();
     rak.write(Cursor::new(&mut buf))

--- a/tests/test_vectors.rs
+++ b/tests/test_vectors.rs
@@ -1,0 +1,52 @@
+use tcn::*;
+
+// Run cargo test generate_test_vectors -- --nocapture
+#[test]
+fn generate_test_vectors() {
+    use std::io::Cursor;
+
+    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+
+    let mut buf = Vec::new();
+    rak.write(Cursor::new(&mut buf))
+        .expect("writing should succeed");
+    println!("rak:\n{}", hex::encode(&buf));
+
+    let mut tck = rak.initial_temporary_contact_key();
+
+    let mut buf = Vec::new();
+    tck.write(Cursor::new(&mut buf))
+        .expect("writing should succeed");
+    let rvk_bytes = &buf[2..2 + 32];
+    println!("rvk:\n{}", hex::encode(rvk_bytes));
+
+    for i in 1..10 {
+        assert_eq!(i, tck.index());
+        let mut buf = Vec::new();
+        tck.write(Cursor::new(&mut buf))
+            .expect("writing should succeed");
+        // Only print the tck_bytes themselves
+        let tck_bytes = &buf[2 + 32..2 + 32 + 32];
+        println!("tck_{}:\n{}", i, hex::encode(tck_bytes));
+
+        let tcn = tck.temporary_contact_number();
+        println!("tcn_{}:\n{}", i, hex::encode(&tcn.0));
+
+        tck = tck.ratchet().unwrap();
+    }
+
+    let signed_report = rak
+        .create_report(
+            MemoType::CoEpiV1,        // The memo type
+            b"symptom data".to_vec(), // The memo data
+            2,                        // Index of the first TCN to disclose
+            10,                       // Index of the last TCN to check
+        )
+        .expect("Report creation can only fail if the memo data is too long");
+
+    let mut buf = Vec::new();
+    signed_report
+        .write(Cursor::new(&mut buf))
+        .expect("writing should succeed");
+    println!("signed_report:\n{}", hex::encode(&buf));
+}


### PR DESCRIPTION


This should be followed by a test that hardcodes some set of these test
vectors and checks that they are accepted by the implementation, but
it's useful for generating test vectors.

