### PR TITLE
Ensure that all reported CENs are bound to rvk.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     /// An unknown memo type was encountered while parsing a report.
     #[error("Unknown memo type {0}")]
     UnknownMemoType(u8),
+    /// Reports cannot include the CEN with index 0.
+    #[error("Invalid CEN index in report")]
+    InvalidReportIndex,
     /// An underlying I/O error occurred while parsing data.
     #[error("I/O error {0}")]
     Io(#[from] std::io::Error),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -38,11 +38,14 @@ impl ReportAuthorizationKey {
             bytes
         };
 
+        // Immediately ratchet cek_0 to return cek_1.
         ContactEventKey {
             index: 0,
             rvk,
             cek_bytes,
         }
+        .ratchet()
+        .expect("0 < u16::MAX")
     }
 }
 
@@ -97,6 +100,7 @@ impl ContactEventKey {
                 bytes.copy_from_slice(
                     &Sha256::default()
                         .chain(H_CEK_DOMAIN_SEP)
+                        .chain(&rvk)
                         .chain(&cek_bytes)
                         .result()[..],
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,14 @@
 //!
 //! ```
 //! use cen::*;
+//! # // Copied from tests/basic_functionality.rs; update it there.
 //! // Generate a report authorization key.  This key represents the capability
 //! // to publish a report about a collection of derived contact event numbers.
 //! let rak = ReportAuthorizationKey::new(rand::thread_rng());
 //!
 //! // Use the contact event key ratchet mechanism to compute a list of contact
 //! // event numbers.
-//! let mut cek = rak.initial_contact_event_key();
+//! let mut cek = rak.initial_contact_event_key(); // cek <- cek_1
 //! let mut cens = Vec::new();
 //! for _ in 0..100 {
 //!     cens.push(cek.contact_event_number());
@@ -39,7 +40,7 @@
 //!         MemoType::CoEpiV1,        // The memo type
 //!         b"symptom data".to_vec(), // The memo data
 //!         20,                       // Index of the first CEN to disclose
-//!         100,                      // Index of the last CEN to check
+//!         90,                       // Index of the last CEN to check
 //!     )
 //!     .expect("Report creation can only fail if the memo data is too long");
 //!
@@ -52,7 +53,8 @@
 //! let recomputed_cens = report.contact_event_numbers().collect::<Vec<_>>();
 //!
 //! // Check that the recomputed CENs match the originals.
-//! assert_eq!(&recomputed_cens[..], &cens[20..100]);
+//! // The slice is offset by 1 because cen_0 is not included.
+//! assert_eq!(&recomputed_cens[..], &cens[20 - 1..90 - 1]);
 //! ```
 
 #![deny(missing_docs)]

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -57,14 +57,21 @@ impl Report {
 
     /// Try to read a `Report` from a generic `io::Read`er.
     pub fn read<R: std::io::Read>(mut reader: R) -> Result<Report, Error> {
-        Ok(Report {
+        let report = Report {
             rvk: reader.read_32_bytes()?.into(),
             cek_bytes: reader.read_32_bytes()?,
             j_1: reader.read_u16::<LittleEndian>()?,
             j_2: reader.read_u16::<LittleEndian>()?,
             memo_type: reader.read_u8()?.try_into()?,
             memo_data: reader.read_compact_vec()?,
-        })
+        };
+
+        // Invariant: j_1 > 0
+        if report.j_1 > 0 {
+            Ok(report)
+        } else {
+            Err(Error::InvalidReportIndex)
+        }
     }
 
     /// Try to write a `Report` into a generic `io::Write`er.

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -8,7 +8,7 @@ fn generate_contact_event_numbers_and_report_them() {
 
     // Use the contact event key ratchet mechanism to compute a list of contact
     // event numbers.
-    let mut cek = rak.initial_contact_event_key();
+    let mut cek = rak.initial_contact_event_key(); // cek <- cek_1
     let mut cens = Vec::new();
     for _ in 0..100 {
         cens.push(cek.contact_event_number());
@@ -21,7 +21,7 @@ fn generate_contact_event_numbers_and_report_them() {
             MemoType::CoEpiV1,        // The memo type
             b"symptom data".to_vec(), // The memo data
             20,                       // Index of the first CEN to disclose
-            100,                      // Index of the last CEN to check
+            90,                       // Index of the last CEN to check
         )
         .expect("Report creation can only fail if the memo data is too long");
 
@@ -34,7 +34,8 @@ fn generate_contact_event_numbers_and_report_them() {
     let recomputed_cens = report.contact_event_numbers().collect::<Vec<_>>();
 
     // Check that the recomputed CENs match the originals.
-    assert_eq!(&recomputed_cens[..], &cens[20..100]);
+    // The slice is offset by 1 because cen_0 is not included.
+    assert_eq!(&recomputed_cens[..], &cens[20 - 1..90 - 1]);
 }
 
 #[test]

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -53,7 +53,7 @@ fn basic_read_write_round_trip() {
         .expect("writing should succeed");
     assert_eq!(buf1, buf2);
 
-    let mut cek = rak.initial_contact_event_key();
+    let cek = rak.initial_contact_event_key();
 
     let mut buf1 = Vec::new();
     let mut buf2 = Vec::new();


### PR DESCRIPTION
Closes #44.

This was an error I introduced when streamlining the previous iteration of the protocol design to always have public verifiability (i.e., it was not included in the Danezis suggestion).

The CEK included in the report must be the one with index `j1-1`, not index `j1`, because the recipient of the report cannot verify that the provided CEK was generated bound to `rvk`. Otherwise a malicious user can submit a report containing a single CEK (the first one) which they did not generate.  This mistake was pointed out by Joseph Jaeger and Stefano Tessaro.

To fix this, the report should include `cek_{j1-1}` rather than `cek_j1`, and the initial `cek_0` should be ratcheted immediately to `cek_1`, rather than being used to generate a CEN.