### PR TITLE
Add a BTreeSet-based matching example, and fix a bug creating reports with tcn_1.

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -55,7 +55,7 @@ impl ReportAuthorizationKey {
 }
 
 /// A pseudorandom 128-bit value broadcast to nearby devices over Bluetooth.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct TemporaryContactNumber(pub [u8; 16]);
 
 /// A ratcheting key used to derive temporary contact numbers.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -22,7 +22,15 @@ impl ReportAuthorizationKey {
     }
 
     /// Compute the initial temporary contact key derived from this report authorization key.
+    ///
+    /// Note: this function returns `tck_1`, the first temporary contact key that can be
+    /// used to generate tcks.
     pub fn initial_temporary_contact_key(&self) -> TemporaryContactKey {
+        self.tck_0().ratchet().expect("0 < u16::MAX")
+    }
+
+    // This is pub(crate) because tck_0 shouldn't be used to generate a tcn.
+    pub(crate) fn tck_0(&self) -> TemporaryContactKey {
         let rvk = ed25519_zebra::PublicKeyBytes::from(&self.rak);
 
         let tck_bytes = {
@@ -38,14 +46,11 @@ impl ReportAuthorizationKey {
             bytes
         };
 
-        // Immediately ratchet tck_0 to return tck_1.
         TemporaryContactKey {
             index: 0,
             rvk,
             tck_bytes,
         }
-        .ratchet()
-        .expect("0 < u16::MAX")
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -90,9 +90,8 @@ impl ReportAuthorizationKey {
         // Recompute tck_{j_1-1}. This requires recomputing j_1-1 hashes, but
         // creating reports is done infrequently and it means we don't force the
         // caller to have saved all intermediate hashes.
-        let mut tck = self.initial_temporary_contact_key();
-        // initial_temporary_contact_key returns tck_1, so begin iteration at 1.
-        for _ in 1..(j_1 - 1) {
+        let mut tck = self.tck_0();
+        for _ in 0..(j_1 - 1) {
             tck = tck.ratchet().expect("j_1 - 1 < u16::MAX");
         }
 

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -39,6 +39,72 @@ fn generate_temporary_contact_numbers_and_report_them() {
 }
 
 #[test]
+fn match_btreeset() {
+    // Simulate many users generating TCNs, some of them being observed,
+    // and comparison of observed TCNs against report data.
+
+    // Use a BTreeSet to efficiently match TCNs.
+    use rand::{
+        distributions::{Bernoulli, Distribution},
+        thread_rng,
+    };
+    use std::collections::BTreeSet;
+
+    // Parameters.
+    let num_reports = 10_000;
+    let tcns_per_report: u16 = 24 * 60 / 15;
+    let tcn_observation = Bernoulli::new(0.001).unwrap();
+
+    // Store observed tcns.
+    let mut observed_tcns = BTreeSet::new();
+
+    // Generate some tcns that will be reported.
+    let reports = (0..num_reports)
+        .map(|_| {
+            let rak = ReportAuthorizationKey::new(thread_rng());
+            let mut tck = rak.initial_temporary_contact_key();
+            for _ in 1..tcns_per_report {
+                if tcn_observation.sample(&mut thread_rng()) {
+                    observed_tcns.insert(tck.temporary_contact_number());
+                }
+                tck = tck.ratchet().expect("tcns_per_report < u16::MAX");
+            }
+
+            rak.create_report(MemoType::CoEpiV1, Vec::new(), 1, tcns_per_report)
+                .expect("empty memo is not too long, so report creation cannot fail")
+        })
+        .collect::<Vec<_>>();
+
+    // The current observed_tcns are exactly the ones that we expect will be reported.
+    let expected_reported_tcns = observed_tcns.clone();
+
+    // Generate some extra tcns that will not be reported.
+    {
+        let rak = ReportAuthorizationKey::new(thread_rng());
+        let mut tck = rak.initial_temporary_contact_key();
+        for _ in 1..60_000 {
+            observed_tcns.insert(tck.temporary_contact_number());
+            tck = tck.ratchet().expect("60_000 < u16::MAX");
+        }
+    }
+
+    // Now expand the reports into a second BTreeSet of candidates.
+    let mut candidate_tcns = BTreeSet::new();
+    for report in reports.into_iter() {
+        let report = report.verify().expect("test reports should be valid");
+        candidate_tcns.extend(report.temporary_contact_numbers());
+    }
+
+    // Compute the intersection of the two BTreeSets.
+    let reported_tcns = candidate_tcns
+        .intersection(&observed_tcns)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(reported_tcns, expected_reported_tcns);
+}
+
+#[test]
 fn basic_read_write_round_trip() {
     use std::io::Cursor;
 

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -88,20 +88,41 @@ fn match_btreeset() {
         }
     }
 
+    use std::time::Instant;
+
+    println!("Expanding candidates");
+
+    let expansion_start = Instant::now();
     // Now expand the reports into a second BTreeSet of candidates.
     let mut candidate_tcns = BTreeSet::new();
     for report in reports.into_iter() {
         let report = report.verify().expect("test reports should be valid");
         candidate_tcns.extend(report.temporary_contact_numbers());
     }
+    let expansion_time = expansion_start.elapsed();
 
+    println!(
+        "Comparing {} candidates against {} observations",
+        candidate_tcns.len(),
+        observed_tcns.len()
+    );
+
+    let comparison_start = Instant::now();
     // Compute the intersection of the two BTreeSets.
     let reported_tcns = candidate_tcns
         .intersection(&observed_tcns)
         .cloned()
         .collect::<BTreeSet<_>>();
+    let comparison_time = comparison_start.elapsed();
 
     assert_eq!(reported_tcns, expected_reported_tcns);
+
+    println!(
+        "Took {:?} (expansion) + {:?} (comparison) = {:?} (total)",
+        expansion_time,
+        comparison_time,
+        (expansion_time + comparison_time),
+    );
 }
 
 #[test]


### PR DESCRIPTION
A BTreeSet seems likely to be a fairly efficient structure for performing comparisons between TCN sets.  The ordering allows us to look in the right place for potential matches, and the B-Tree structure balances minimizing the amount of work performed with cache efficiency.

This PR adds a test that compares matching observed TCNs against reported ones. The test essentially runs a lightweight simulation where one user randomly encounters `n` other users in each TCN broadcast window according to the Bernoulli distribution (i.e., the user has probability `p` of observing any TCN).  These TCNs are saved as the expected observations, then mixed in with other TCNs that will not be included in reports.  Finally, the user expands `n` reports to the TCNs they reveal, performs matching, and checks that the matched TCNs are the expected ones.

The test revealed a bug in generating reports including `tcn_1`.  The previous code inserted `tck_1` rather than `tck_0`.

The test also reports basic timing information: 
```
~/c/c/TCN (match-btreeset|✔) $ cargo test --release match -- --nocapture
[...snipped...]
running 1 test
Expanding candidates
Comparing 950000 candidates against 60941 observations
Took 1.780357333s (expansion) + 18.400804ms (comparison) = 1.798758137s (total)
test match_btreeset ... ok
```
Here we were able to generate and match close to a million TCNs on a single thread on a laptop in under two seconds.  High-end mobile devices have comparable performance; low-end devices will be slower, but probably within an order of magnitude.  This timing also includes verification of all of the report signatures.  Signature verification can be made significantly faster using batch verification, or dropped entirely by relying on a trusted server.
