### PR TITLE
Possible fix for tck_0 used in first reports

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -41,7 +41,7 @@ impl Report {
     pub fn temporary_contact_numbers(&self) -> impl Iterator<Item = TemporaryContactNumber> {
         let mut tck = TemporaryContactKey {
             // Does not underflow as j_1 > 0.
-            index: self.j_1 - 1,
+            index: self.j_1,
             rvk: self.rvk,
             tck_bytes: self.tck_bytes,
         };
@@ -85,13 +85,14 @@ impl ReportAuthorizationKey {
         j_2: u16,
     ) -> Result<SignedReport, Error> {
         // Ensure that j_1 is at least 1.
-        let j_1 = if j_1 == 0 { 1 } else { j_1 };
+        let j_1 = j_1 + 1;
 
         // Recompute tck_{j_1-1}. This requires recomputing j_1-1 hashes, but
         // creating reports is done infrequently and it means we don't force the
         // caller to have saved all intermediate hashes.
         let mut tck = self.tck_0();
-        for _ in 0..(j_1 - 1) {
+
+        for _ in 0..j_1 {
             tck = tck.ratchet().expect("j_1 - 1 < u16::MAX");
         }
 

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -35,7 +35,7 @@ fn generate_temporary_contact_numbers_and_report_them() {
 
     // Check that the recomputed TCNs match the originals.
     // The slice is offset by 1 because tcn_0 is not included.
-    assert_eq!(&recomputed_tcns[..], &tcns[20 - 1..90 - 1]);
+    assert_eq!(&recomputed_tcns[..], &tcns[20 + 1..90]);
 }
 
 #[test]


### PR DESCRIPTION
I noticed that `tck_0` is being used for the first 2 generated reports, which seems invalid, as `tck_0` can't generate TCNs. The repetition of the key, by coercing 0 to 1, seems problematic too.

This change increases `j1` always by 1, offsetting the entire keys sequence. I'm not quite sure about the implications, so it's very experimental. Mostly just an attempt to understand the problem. Maybe it's useful.

I adjusted the `generate_temporary_contact_numbers_and_report_them` unit test. `match_btreeset` is failing. It's better to clear up first whether this change makes sense before continuing working on it.