### PR TITLE
Make the report's signature public

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -118,7 +118,8 @@ impl ReportAuthorizationKey {
 #[derive(Clone, Debug)]
 pub struct SignedReport {
     pub(crate) report: Report,
-    pub(crate) sig: ed25519_zebra::Signature,
+    /// The report's signature
+    pub sig: ed25519_zebra::Signature,
 }
 
 impl SignedReport {


### PR DESCRIPTION
This allows us to identify uniquely the reports in the database.