### PR TITLE
Fix not generating TCNs when j2 is 1 and j1 is 0 or 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! // Check that the recomputed TCNs match the originals.
 //! // The slice is offset by 1 because tcn_0 is not included.
-//! assert_eq!(&recomputed_tcns[..], &tcns[20 - 1..90 - 1]);
+//! assert_eq!(&recomputed_tcns[..], &tcns[20 - 1..90]);
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/tcn/0.4.1")]

--- a/src/report.rs
+++ b/src/report.rs
@@ -48,11 +48,13 @@ impl Report {
         // Ratchet to obtain tck_{j_1}.
         tck = tck.ratchet().expect("j_1 - 1 < j_1 <= u16::MAX");
 
-        (self.j_1..self.j_2).map(move |_| {
+        (self.j_1..=self.j_2).map(move |j| {
             let tcn = tck.temporary_contact_number();
-            tck = tck
-                .ratchet()
-                .expect("we do not ratchet past j_2 <= u16::MAX");
+            if j < u16::MAX {
+                tck = tck
+                    .ratchet()
+                    .expect("we do not ratchet past j_2 <= u16::MAX");
+            }
             tcn
         })
     }

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -35,7 +35,7 @@ fn generate_temporary_contact_numbers_and_report_them() {
 
     // Check that the recomputed TCNs match the originals.
     // The slice is offset by 1 because tcn_0 is not included.
-    assert_eq!(&recomputed_tcns[..], &tcns[20 - 1..90 - 1]);
+    assert_eq!(&recomputed_tcns[..], &tcns[20 - 1..90]);
 }
 
 #[test]
@@ -187,4 +187,73 @@ fn basic_read_write_round_trip() {
         .write(Cursor::new(&mut buf2))
         .expect("writing should succeed");
     assert_eq!(buf1, buf2);
+}
+
+#[test]
+fn report_with_j1_0_and_j2_1_generates_one_tcn() {
+    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+
+    let signed_report = rak
+        .create_report(MemoType::CoEpiV1, b"symptom data".to_vec(), 0, 1)
+        .expect("Report creation can only fail if the memo data is too long");
+
+    let report = signed_report
+        .verify()
+        .expect("Valid reports should verify correctly");
+
+    let recomputed_tcns = report.temporary_contact_numbers().collect::<Vec<_>>();
+    assert_eq!(recomputed_tcns.len(), 1);
+}
+
+#[test]
+fn report_with_j1_1_and_j2_1_generates_one_tcn() {
+    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+
+    let signed_report = rak
+        .create_report(MemoType::CoEpiV1, b"symptom data".to_vec(), 0, 1)
+        .expect("Report creation can only fail if the memo data is too long");
+
+    let report = signed_report
+        .verify()
+        .expect("Valid reports should verify correctly");
+
+    let recomputed_tcns = report.temporary_contact_numbers().collect::<Vec<_>>();
+    assert_eq!(recomputed_tcns.len(), 1);
+}
+
+#[test]
+fn report_with_j1_1_and_j2_2_generates_2_tcns() {
+    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+
+    let signed_report = rak
+        .create_report(MemoType::CoEpiV1, b"symptom data".to_vec(), 1, 2)
+        .expect("Report creation can only fail if the memo data is too long");
+
+    let report = signed_report
+        .verify()
+        .expect("Valid reports should verify correctly");
+
+    let recomputed_tcns = report.temporary_contact_numbers().collect::<Vec<_>>();
+    assert_eq!(recomputed_tcns.len(), 2);
+}
+
+#[test]
+fn report_with_j2_max_and_j1_max_minus_1_generates_2_tcns() {
+    let rak = ReportAuthorizationKey::new(rand::thread_rng());
+
+    let signed_report = rak
+        .create_report(
+            MemoType::CoEpiV1,
+            b"symptom data".to_vec(),
+            u16::MAX - 1,
+            u16::MAX,
+        )
+        .expect("Report creation can only fail if the memo data is too long");
+
+    let report = signed_report
+        .verify()
+        .expect("Valid reports should verify correctly");
+
+    let recomputed_tcns = report.temporary_contact_numbers().collect::<Vec<_>>();
+    assert_eq!(recomputed_tcns.len(), 2);
 }

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -210,7 +210,7 @@ fn report_with_j1_1_and_j2_1_generates_one_tcn() {
     let rak = ReportAuthorizationKey::new(rand::thread_rng());
 
     let signed_report = rak
-        .create_report(MemoType::CoEpiV1, b"symptom data".to_vec(), 0, 1)
+        .create_report(MemoType::CoEpiV1, b"symptom data".to_vec(), 1, 1)
         .expect("Report creation can only fail if the memo data is too long");
 
     let report = signed_report


### PR DESCRIPTION
After discussing the issue again with @duskoo here's a possible new fix, which adjusts the iterator range.

@duskoo feel free to continue working on it. This can be probably written better.