### PR TITLE
Reserving memo type for HutchTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ encoded by the `type` field, which has the following meaning:
 - `0x0`: CoEpi symptom report v1;
 - `0x1`: CovidWatch test result v1;
 - `0x2`: ito report v1;
-- `0x3-0xfe`: reserved for allocations to applications on request;
+- `0x3`: HutchTrace;
+- `0x4-0xfe`: reserved for allocations to applications on request;
 - `0xff`: reserved (can be used to add more than 256 types later).
 
 **Parameter Choices**. We implement 


### PR DESCRIPTION
We are trying to implement contact tracing for internal use at Fred Hutchinson Cancer Research Center as a research study. I would like to reserve this memo type. I will add a link to the project once its available.